### PR TITLE
fix TLS server fingerprint is: undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ function Request() {
 				req.abort();
 				callback(createErrorMessage("request.ssl.security.domain.invalid",url));
 			}
-			else if (shouldMatch!==fingerprint) {
+			else if (fingerprint && shouldMatch !== fingerprint) {
 				req.abort();
 				callback(createErrorMessage("request.ssl.security.domain.fingerprint.mismatch",url));
 			}


### PR DESCRIPTION
fix uri call https, but server  fingerprint not found `TLS server fingerprint is: undefined.`


**log request-ssl**
```
 request-ssl init called undefined +4ms
 request-ssl init is calling real init +1ms
 request-ssl TLS connection established to https://xxx.org +410ms
 request-ssl TLS response final url fxxx.org, begin with https://xxx.org +442ms
 request-ssl getFingerprintForURL xxx.org -> xxx.org=XX:XX:XX +1ms
 request-ssl TLS server fingerprint is: undefined, expected: XX:XX:XX +2ms
```